### PR TITLE
Add github action for pull request

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -7,6 +7,9 @@
       "hosting": {
         "production": [
           "tobeyou-facilitator"
+        ],
+        "staging": [
+          "tobeyou-facilitator-staging"
         ]
       }
     }

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -1,0 +1,41 @@
+name: STG - Deploy to Firebase Hosting on PR
+'on': pull_request
+# 'on':
+#   pull_request:
+#     branches:
+#       - release
+jobs:
+  build_and_preview:
+    runs-on: ubuntu-latest
+    env:
+      FIREBASE_CLI_PREVIEWS: hostingchannels
+      REACT_APP_NAME: ToBeYou
+      REACT_APP_VERSION: 1
+      REACT_APP_DESCRIPTION: ToBeYou - Facilitator Dashboard
+      REACT_APP_HOMEPAGE: https://facilitator.tobeyou.sg
+      REACT_APP_TITLE: ToBeYou - Facilitator Dashboard
+      REACT_APP_THEME_PRIMARY_COLOR: blue
+      REACT_APP_THEME_SECONDARY_COLOR: red
+      REACT_APP_THEME_DARK: false
+      # REACT_APP_SENTRY_DSN: https://bb146ffc4f074171bcf4a41bba43de17@o374848.ingest.sentry.io/5193525
+      REACT_APP_FIREBASE_API_KEY: ${{ secrets.REACT_APP_FIREBASE_API_KEY }}
+      REACT_APP_FIREBASE_AUTH_DOMAIN: facilitator.tobeyou.sg
+      REACT_APP_FIREBASE_PROJECT_ID: besomebody
+      REACT_APP_FIREBASE_STORAGE_BUCKET: besomebody.appspot.com
+      REACT_APP_FIREBASE_MESSAGING_SENDER_ID: 1058004825790
+      REACT_APP_FIREBASE_APP_ID: 1:1058004825790:web:ac88b88b79c7ea516dd0ef
+      REACT_APP_FIREBASE_MEASUREMENT_ID: G-GZRNC2KL45
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: npm install && CI=false npm run build
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_BESOMEBODY }}'
+          projectId: besomebody
+          target: staging
+        env:
+          FIREBASE_CLI_PREVIEWS: hostingchannels

--- a/firebase.json
+++ b/firebase.json
@@ -1,11 +1,14 @@
 {
-  "hosting": {
-    "target": "production",
-    "public": "build",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ]
-  }
+  "hosting": [
+    {
+      "target": "production",
+      "public": "build",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    },
+    {
+      "target": "staging",
+      "public": "build",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    }
+  ]
 }


### PR DESCRIPTION
This deploys a preview channel on firebase hosting upon a new pull request.

This action is referenced from the github actions in the besomebody_v3 project: it uses the same overall firebase project (BeSomebody), but a different hosting site for prod vs staging.

EDIT: added a `CI=false` before `npm run build` -- this prevents lint warnings from becoming errors that cause a compilation failure.