### PR TITLE
Fix inability to get user information from db when signing in

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -6,7 +6,7 @@ const AuthContext = React.createContext(null);
 
 export const useAuth = () => {
   return useContext(AuthContext);
-}
+};
 
 export const AuthProvider = ({ children }) => {
   const [currentUser, setCurrentUser] = useState(null);
@@ -15,57 +15,61 @@ export const AuthProvider = ({ children }) => {
 
   const signUp = async (email, password) => {
     return await auth.createUserWithEmailAndPassword(email, password);
-  }
+  };
 
   const login = async (email, password) => {
     return await auth.signInWithEmailAndPassword(email, password);
-  }
+  };
 
   /**
    * Logs in the user only if they have already been registered as a facilitator.
    */
   const loginOnlyFacilitators = async (email, password) => {
-    // TODO: this approach is hacky and requires signing in twice. Is there a better way?
     setIsLoggingInFacilitator(true);
-    // Sign in the first time just to get the user's ID, and use it to check if they're a facilitator
-    const userCredential = await auth.signInWithEmailAndPassword(email, password);
-    const userId = userCredential.user.uid;
-    // Sign out immediately to avoid 'wrongfully' signing them in if they're not actually a facilitator
-    await auth.signOut();
-    const user = await getDbUser(userId);
+    const userCredential = await auth.signInWithEmailAndPassword(
+      email,
+      password
+    );
 
+    // Check if the user is a facilitator, and sign them out if they're not
+    // We must first sign in the user to check this, because of our firestore auth rules
+    const userId = userCredential.user.uid;
+    const user = await getDbUser(userId);
     if (!user.isFacilitator) {
-      throw new Error('The user exists, but is not registered as a facilitator yet.');
+      await auth.signOut();
+      throw new Error(
+        'The user exists, but is not registered as a facilitator yet.'
+      );
     }
 
-    // User is actually a facilitator, so sign them in proper the second time
-    await auth.signInWithEmailAndPassword(email, password);
     setIsLoggingInFacilitator(false);
     return userCredential;
-  }
+  };
 
   const logout = async () => {
     return await auth.signOut();
-  }
+  };
 
   const resetPassword = async (email) => {
     return await auth.sendPasswordResetEmail(email);
-  }
+  };
 
   const deleteUser = async () => {
     return await auth.currentUser.delete();
-  }
+  };
 
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged(async (user) => {
-      const { uid, ...rest } = user || {}
-      const nextCurrentUser = user ? {
-        ...rest,
-        id: uid,
-      } : null
+      const { uid, ...rest } = user || {};
+      const nextCurrentUser = user
+        ? {
+            ...rest,
+            id: uid,
+          }
+        : null;
       setCurrentUser(nextCurrentUser);
       setIsLoading(false);
-    })
+    });
 
     return unsubscribe;
   }, []);


### PR DESCRIPTION
The user must be signed in before we can get their user information from db, as per the besomebody project's current firestore auth rules

To log in facilitators only, we do the following:
- Sign in the user
- Pull user's info from db, and check their `isFacilitator` field
- If user is not facilitator, we sign them out and throw an error; otherwise carry on