### PR TITLE
Update new room modal with new layout

### DIFF
--- a/src/components/dashboard/NewRoomModal.jsx
+++ b/src/components/dashboard/NewRoomModal.jsx
@@ -3,7 +3,6 @@ import QRCode from 'react-qr-code';
 import moment from 'moment';
 import {
   Box,
-  Button,
   Checkbox,
   FormControlLabel,
   FormGroup,
@@ -15,6 +14,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
+import { ContentCopy, MailOutline, WhatsApp } from '@mui/icons-material';
 import { createDbRoomIfNotExists } from '../../models/roomModel';
 import { getDbUser } from '../../models/userModel';
 import { useAuth } from '../../contexts/AuthContext';
@@ -35,7 +35,228 @@ const initialFormData = {
   date: moment().format('YYYY-MM-DD'),
   instructions: '',
 };
-const steps = ['Enter room details', 'Message for participants'];
+
+const SuccessPanel = ({ createdRoom, handleCloseModal }) => {
+  // TODO: refactor?
+  const getGameUrl = (code) => {
+    return `game.tobeyou.sg/room/${code}`;
+  };
+
+  const gameUrl = getGameUrl(createdRoom.code);
+
+  return (
+    <React.Fragment>
+      <Typography variant='h4'>Class set up!</Typography>
+      <Typography>Share with your class</Typography>
+      <QRCode value={gameUrl} />
+      <Typography>
+        <Link href={'https://' + gameUrl}>{gameUrl}</Link>
+      </Typography>
+      <Typography>Share via:</Typography>
+      <WhatsApp />
+      <MailOutline />
+      <ContentCopy />
+      <GeneralButton variant='contained' onClick={handleCloseModal}>
+        Return to dashboard
+      </GeneralButton>
+      <ModalRightSide>
+        <Typography variant='h4'>What's next?</Typography>
+        <Typography variant='h6'>Let's get you ready for class</Typography>
+        <Typography variant='h5'>Check out the Lesson Plan</Typography>
+        <Typography variant='h5'>Play the game</Typography>
+      </ModalRightSide>
+    </React.Fragment>
+  );
+};
+
+const ModalStepper = ({ steps, activeStep }) => {
+  return (
+    <Stepper
+      activeStep={activeStep}
+      sx={{ position: 'absolute', bottom: 20, width: '10%' }}
+      connector={<ModalStepConnector />}
+      alternativeLabel
+    >
+      {steps.map((_, index) => {
+        return (
+          <Step key={index}>
+            <StepLabel />
+          </Step>
+        );
+      })}
+    </Stepper>
+  );
+};
+
+const Step0 = ({
+  formData,
+  handleChange,
+  handleSubmit,
+  handleNextStep,
+  isSubmitting,
+}) => {
+  return (
+    <form onSubmit={handleSubmit}>
+      <Box>
+        <FlexBoxCenterColumn sx={{ p: 10 }}>
+          <Typography id='modal-modal-title' variant='h4' component='h2'>
+            Add a new class
+          </Typography>
+          <Typography variant='h6'>Organisation:</Typography>
+          <GeneralTextField
+            name='organisation'
+            variant='filled'
+            defaultValue={formData.organisation}
+            onChange={handleChange}
+            disabled={isSubmitting}
+          />
+          <Typography variant='h6'>Class:</Typography>
+          <GeneralTextField
+            name='name'
+            variant='filled'
+            defaultValue={formData.name}
+            onChange={handleChange}
+            disabled={isSubmitting}
+          />
+          <Typography variant='h6'>Date:</Typography>
+          <GeneralTextField
+            name='date'
+            variant='filled'
+            type='date'
+            defaultValue={formData.date}
+            onChange={handleChange}
+            disabled={isSubmitting}
+          />
+          <GeneralButton
+            variant='contained'
+            onClick={handleNextStep}
+            disabled={isSubmitting}
+            style={{ marginTop: 10, width: '250px' }}
+          >
+            Next: Assign Chapters
+          </GeneralButton>
+        </FlexBoxCenterColumn>
+      </Box>
+    </form>
+  );
+};
+
+const Step1 = ({
+  formData,
+  handleSubmit,
+  handleNextStep,
+  handleBackStep,
+  toggleChapterCheckbox,
+  isSubmitting,
+}) => {
+  return (
+    <form onSubmit={handleSubmit}>
+      <Box>
+        <FlexBoxCenterColumn>
+          <Typography id='modal-modal-title' variant='h4' component='h2'>
+            Assign chapters
+          </Typography>
+          {Object.keys(CHARACTER_MAP).map((character) => {
+            const chapterMap = CHARACTER_MAP[character];
+            return (
+              <FormGroup key={character}>
+                <Typography>{character}</Typography>
+                {Object.keys(chapterMap).map((reflectionId) => {
+                  const chapterName = chapterMap[reflectionId];
+                  return (
+                    <FormControlLabel
+                      key={reflectionId}
+                      control={
+                        <Checkbox
+                          checked={formData.reflectionIds.some(
+                            (id) => id === parseInt(reflectionId)
+                          )}
+                          onChange={toggleChapterCheckbox}
+                          name={reflectionId}
+                        />
+                      }
+                      label={chapterName}
+                    />
+                  );
+                })}
+              </FormGroup>
+            );
+          })}
+          <GeneralButton
+            variant='contained'
+            onClick={handleNextStep}
+            disabled={isSubmitting}
+            style={{ marginTop: 10, width: '250px' }}
+          >
+            Next: Message to Participants
+          </GeneralButton>
+          <GeneralButton
+            variant='contained'
+            onClick={handleBackStep}
+            disabled={isSubmitting}
+            style={{ marginTop: 10, width: '250px' }}
+          >
+            Back
+          </GeneralButton>
+        </FlexBoxCenterColumn>
+      </Box>
+    </form>
+  );
+};
+
+const Step2 = ({
+  formData,
+  handleChange,
+  handleSubmit,
+  handleBackStep,
+  isSubmitting,
+}) => {
+  return (
+    <form onSubmit={handleSubmit}>
+      <Typography id='modal-modal-title' variant='h4' component='h2'>
+        Message to participants
+      </Typography>
+      <Typography variant='h6'>
+        We'll show the instructions to your class when they play the game
+      </Typography>
+      <FlexBoxCenterColumn>
+        <TextField
+          style={{ width: 350 }}
+          multiline
+          name='instructions'
+          label='Instructions'
+          variant='filled'
+          defaultValue={formData.instructions}
+          minRows={3}
+          maxRows={7}
+          onChange={handleChange}
+          disabled={isSubmitting}
+        />
+        <GeneralButton
+          variant='contained'
+          onClick={handleSubmit}
+          disabled={isSubmitting}
+          style={{ marginTop: 10, width: '250px' }}
+        >
+          Confirm
+        </GeneralButton>
+        <GeneralButton
+          variant='contained'
+          onClick={handleBackStep}
+          disabled={isSubmitting}
+          style={{ marginTop: 10, width: '250px' }}
+        >
+          Back
+        </GeneralButton>
+      </FlexBoxCenterColumn>
+      <ModalRightSide>
+        <Typography variant='h6'>
+          Sample of what players see when they enter the game
+        </Typography>
+      </ModalRightSide>
+    </form>
+  );
+};
 
 const NewRoomModal = (props) => {
   const { isNewRoomModalOpen, setIsNewRoomModalOpen, loadRooms } = props;
@@ -50,18 +271,12 @@ const NewRoomModal = (props) => {
     // credits: https://stackoverflow.com/questions/1349404/generate-random-string-characters-in-javascript
     const CODE_LENGTH = 6;
     let code = '';
-    const characters =
-      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
     const charactersLength = characters.length;
     for (let i = 0; i < CODE_LENGTH; i++) {
       code += characters.charAt(Math.floor(Math.random() * charactersLength));
     }
     return code;
-  };
-
-  // TODO: refactor?
-  const getGameUrl = (code) => {
-    return `game.tobeyou.sg/room/${code}`;
   };
 
   const handleChange = (event) => {
@@ -149,6 +364,36 @@ const NewRoomModal = (props) => {
 
   useEffect(() => getUserOrganisation(), []);
 
+  const steps = [
+    <Step0
+      key={0}
+      formData={formData}
+      handleChange={handleChange}
+      handleSubmit={handleSubmit}
+      handleNextStep={handleNextStep}
+      isSubmitting={isSubmitting}
+    />,
+    <Step1
+      key={1}
+      formData={formData}
+      handleSubmit={handleSubmit}
+      handleNextStep={handleNextStep}
+      handleBackStep={handleBackStep}
+      toggleChapterCheckbox={toggleChapterCheckbox}
+      isSubmitting={isSubmitting}
+    />,
+    <Step2
+      key={2}
+      formData={formData}
+      handleChange={handleChange}
+      handleSubmit={handleSubmit}
+      handleBackStep={handleBackStep}
+      isSubmitting={isSubmitting}
+    />,
+  ];
+
+  const currentStep = steps[activeStep];
+
   return (
     <Modal
       open={isNewRoomModalOpen}
@@ -157,171 +402,14 @@ const NewRoomModal = (props) => {
     >
       <ModalBox>
         {createdRoom ? (
-          <React.Fragment>
-            <Typography variant='h6' component='h2'>
-              Success! New room added!
-            </Typography>
-            <QRCode value={getGameUrl(createdRoom.code)} />
-            <Typography>Class: {createdRoom.name}</Typography>
-            <Typography>
-              Reflection IDs: {JSON.stringify(createdRoom.reflectionIds)}
-            </Typography>
-            <Typography>
-              All facilitator IDs: {createdRoom.facilitatorIds.join(', ')}
-            </Typography>
-            <Typography>Date: {JSON.stringify(createdRoom.date)}</Typography>
-            <Typography>Code: {createdRoom.code}</Typography>
-            <Typography>
-              Link:{' '}
-              <Link href={'https://' + getGameUrl(createdRoom.code)}>
-                {getGameUrl(createdRoom.code)}
-              </Link>
-            </Typography>
-            <Button
-              variant='contained'
-              color='primary'
-              onClick={handleCloseModal}
-              style={{ marginTop: 10 }}
-            >
-              Return to dashboard
-            </Button>
-          </React.Fragment>
+          <SuccessPanel
+            createdRoom={createdRoom}
+            handleCloseModal={handleCloseModal}
+          />
         ) : (
           <React.Fragment>
-            <Stepper
-              activeStep={activeStep}
-              sx={{ position: 'absolute', bottom: 20, width: '10%' }}
-              connector={<ModalStepConnector />}
-              alternativeLabel
-            >
-              {steps.map((label) => {
-                return (
-                  <Step key={label}>
-                    <StepLabel />
-                  </Step>
-                );
-              })}
-            </Stepper>
-            {activeStep === 0 ? (
-              <React.Fragment>
-                <div>
-                  <form onSubmit={handleSubmit}>
-                    <Box>
-                      <FlexBoxCenterColumn sx={{ p: 10 }}>
-                        <Typography
-                          id='modal-modal-title'
-                          variant='h5'
-                          component='h2'
-                        >
-                          Add a new class / chapter
-                        </Typography>
-                        <Typography variant='h6'>Organisation:</Typography>
-                        <GeneralTextField
-                          name='organisation'
-                          variant='filled'
-                          defaultValue={formData.organisation}
-                          onChange={handleChange}
-                          disabled={isSubmitting}
-                        />
-                        <Typography variant='h6'>Class:</Typography>
-                        <GeneralTextField
-                          name='name'
-                          variant='filled'
-                          defaultValue={formData.name}
-                          onChange={handleChange}
-                          disabled={isSubmitting}
-                        />
-                        <Typography variant='h6'>Date:</Typography>
-                        <GeneralTextField
-                          name='date'
-                          variant='filled'
-                          type='date'
-                          defaultValue={formData.date}
-                          onChange={handleChange}
-                          disabled={isSubmitting}
-                        />
-                        <GeneralButton
-                          variant='contained'
-                          onClick={handleNextStep}
-                          disabled={isSubmitting}
-                          style={{ marginTop: 10, width: '250px' }}
-                        >
-                          Next
-                        </GeneralButton>
-                      </FlexBoxCenterColumn>
-                      <ModalRightSide>
-                        <Typography variant='h6'>
-                          Character / Chapter:
-                        </Typography>
-                        {Object.keys(CHARACTER_MAP).map((character) => {
-                          const chapterMap = CHARACTER_MAP[character];
-                          return (
-                            <FormGroup key={character}>
-                              <Typography>{character}</Typography>
-                              {Object.keys(chapterMap).map((reflectionId) => {
-                                const chapterName = chapterMap[reflectionId];
-                                return (
-                                  <FormControlLabel
-                                    key={reflectionId}
-                                    control={
-                                      <Checkbox
-                                        checked={formData.reflectionIds.some(
-                                          (id) => id === parseInt(reflectionId)
-                                        )}
-                                        onChange={toggleChapterCheckbox}
-                                        name={reflectionId}
-                                      />
-                                    }
-                                    label={chapterName}
-                                  />
-                                );
-                              })}
-                            </FormGroup>
-                          );
-                        })}
-                      </ModalRightSide>
-                    </Box>
-                  </form>
-                </div>
-              </React.Fragment>
-            ) : (
-              <React.Fragment>
-                <form onSubmit={handleSubmit}>
-                  <Box style={{ display: 'flex', flexDirection: 'column' }}>
-                    <TextField
-                      multiline
-                      name='instructions'
-                      label='Instructions'
-                      variant='filled'
-                      defaultValue={formData.instructions}
-                      minRows={3}
-                      maxRows={7}
-                      onChange={handleChange}
-                      disabled={isSubmitting}
-                    />
-                    <Button
-                      variant='contained'
-                      color='primary'
-                      onClick={handleBackStep}
-                      disabled={isSubmitting}
-                      style={{ marginTop: 10 }}
-                    >
-                      Back
-                    </Button>
-                    <Button
-                      type='submit'
-                      variant='contained'
-                      color='primary'
-                      onClick={handleSubmit}
-                      disabled={isSubmitting}
-                      style={{ marginTop: 10 }}
-                    >
-                      Submit
-                    </Button>
-                  </Box>
-                </form>
-              </React.Fragment>
-            )}
+            <ModalStepper steps={steps} activeStep={activeStep} />
+            {currentStep}
           </React.Fragment>
         )}
       </ModalBox>


### PR DESCRIPTION
Part of #27 

The new room modal has been split into 3 steps (as per the Figma design). It's hardly been styled yet
- Not sure why there's so much empty space in the modal when there's no right side panel :(
- Stepper is still in the wrong location, also it doesn't show up in the last panel (success screen) as it should eventually
- Have changed the room code generation from `[a-zA-Z0-9]{6}` to `[A-Z0-9]{6}`, so letters are only uppercase now. Removes any issues with case-sensitivity, while it should still afford enough combinations - (26+10)^6 is about 2 billion
- Steps have been refactored into separate components with their own props

<img width="864" alt="Screenshot 2022-03-22 at 1 28 58 PM" src="https://user-images.githubusercontent.com/41856541/159414168-84f8a500-d3d1-411b-b651-54e28c7d2eea.png">
<img width="864" alt="Screenshot 2022-03-22 at 1 30 12 PM" src="https://user-images.githubusercontent.com/41856541/159414202-e9175c94-5ee5-4299-8122-a4153785589f.png">
<img width="864" alt="Screenshot 2022-03-22 at 1 30 30 PM" src="https://user-images.githubusercontent.com/41856541/159414230-cce0c5de-65a5-4f57-9923-689d6c5a9119.png">
<img width="864" alt="Screenshot 2022-03-22 at 1 30 44 PM" src="https://user-images.githubusercontent.com/41856541/159414269-1c2357bb-d6c5-4f3a-a6d8-3020df3a10d3.png">

