### PR TITLE
Pull data by `roomCode` instead of `participantRoomIds`

### DIFF
--- a/src/models/quizAnswerModel.js
+++ b/src/models/quizAnswerModel.js
@@ -1,16 +1,19 @@
 import { firestore } from '../firebase';
 
-export const getDbQuizAnswers = async (participantRoomId, gameId) => {
+export const getDbQuizAnswers = async (roomCode, gameId) => {
   try {
     gameId = parseInt(gameId);
     const snapshot = await firestore
       .collection('quizAnswers')
-      .where('participantRoomIds', 'array-contains', participantRoomId)
+      .where('roomCode', '==', roomCode)
       .where('gameId', '==', gameId)
       .get();
-    const quizAnswers = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    const quizAnswers = snapshot.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    }));
     return quizAnswers;
   } catch (err) {
-    throw new Error(`Error at getDbQuizAnswers: ${err}`)
+    throw new Error(`Error at getDbQuizAnswers: ${err}`);
   }
-}
+};

--- a/src/models/reflectionResponseModel.js
+++ b/src/models/reflectionResponseModel.js
@@ -1,19 +1,26 @@
 import { firestore } from '../firebase';
 
-export const getDbReflectionResponses = async (participantRoomId, reflectionId, getOnlyReflections) => {
+export const getDbReflectionResponses = async (
+  roomCode,
+  reflectionId,
+  getOnlyReflections
+) => {
   try {
     reflectionId = parseInt(reflectionId);
     let query = firestore
       .collection('reflectionResponses')
-      .where('participantRoomIds', 'array-contains', participantRoomId)
+      .where('roomCode', '==', roomCode)
       .where('reflectionId', '==', reflectionId);
     if (getOnlyReflections) {
-      query = query.where('questionId', '==', 3)
+      query = query.where('questionId', '==', 3);
     }
     const snapshot = await query.get();
-    const savedStates = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    const savedStates = snapshot.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    }));
     return savedStates;
   } catch (err) {
-    throw new Error(`Error at getDbReflectionResponses: ${err}`)
+    throw new Error(`Error at getDbReflectionResponses: ${err}`);
   }
-}
+};

--- a/src/models/savedStateModel.js
+++ b/src/models/savedStateModel.js
@@ -1,14 +1,18 @@
 import { firestore } from '../firebase';
 
-export const getDbSavedStates = async (participantRoomId) => {
+// TODO: to review - might not need to filter by room code after all.
+export const getDbSavedStates = async (roomCode) => {
   try {
     const snapshot = await firestore
       .collection('savedStates')
-      .where('participantRoomIds', 'array-contains', participantRoomId)
+      .where('roomCode', '==', roomCode)
       .get();
-    const savedStates = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    const savedStates = snapshot.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    }));
     return savedStates;
   } catch (err) {
-    throw new Error(`Error at getDbSavedStates: ${err}`)
+    throw new Error(`Error at getDbSavedStates: ${err}`);
   }
-}
+};

--- a/src/page/Quizzes.jsx
+++ b/src/page/Quizzes.jsx
@@ -90,8 +90,8 @@ const Quizzes = () => {
     ) {
       navigate('/'); // redirect if the room does not exist, or facilitator is unauthorised to access it
     }
-
-    const dbQuizAnswers = await getDbQuizAnswers(roomId, reflectionId); // reflectionId serves as the gameId
+    const roomCode = dbRoom.code;
+    const dbQuizAnswers = await getDbQuizAnswers(roomCode, reflectionId); // reflectionId serves as the gameId
     setQuizAnswers(dbQuizAnswers);
   }
 

--- a/src/page/Reflections.jsx
+++ b/src/page/Reflections.jsx
@@ -99,9 +99,9 @@ const Reflections = () => {
     ) {
       navigate('/'); // redirect if the room does not exist, or facilitator is unauthorised to access it
     }
-
+    const roomCode = dbRoom.code;
     const dbReflectionResponses = await getDbReflectionResponses(
-      roomId,
+      roomCode,
       reflectionId,
       true
     );


### PR DESCRIPTION
Resolves #34.

~Have not tested it yet, so should test it and confirm it works first before merging - also consider what happens in the rogue case where `dbRoom.code` is undefined/null.~ Tested and it seems fine.

Depends on https://github.com/bettersg/besomebody_v3/pull/307

If `room` -> `roomCode`, ensure that firestore documents with the old field are updated to the new field, in the relevant collections (`users`, `quizAnswers`, `reflectionResponses`)