### PR TITLE
Disable default multiline for general text field

### DIFF
--- a/src/components/GeneralTextField/GeneralTextField.jsx
+++ b/src/components/GeneralTextField/GeneralTextField.jsx
@@ -13,27 +13,26 @@ export const GeneralTextField = ({
   onChange,
   disabled,
   children,
-  multiline, 
+  multiline,
   ...props
 }) => {
   return (
     <Box>
       <Typography variant='h6'>{label}</Typography>
 
-        <StyledTextfield
-          select
-          multiline
-          value={value}
-          name={name}
-          variant='filled'
-          placeholder={placeholder}
-          onChange={onChange}
-          disabled={disabled}
-          {...props}
-        >
-          {children}
-        </StyledTextfield>
-
+      <StyledTextfield
+        select
+        multiline={multiline}
+        value={value}
+        name={name}
+        variant='filled'
+        placeholder={placeholder}
+        onChange={onChange}
+        disabled={disabled}
+        {...props}
+      >
+        {children}
+      </StyledTextfield>
     </Box>
   );
 };
@@ -48,10 +47,10 @@ GeneralTextField.propTypes = {
 };
 
 GeneralTextField.defaultProps = {
-  label: "Label:",
-  name: "label",
+  label: 'Label:',
+  name: 'label',
   variant: 'filled',
-  placeholder: "label", 
+  placeholder: 'label',
   onChange: undefined,
   disabled: false,
 };


### PR DESCRIPTION
Fixes #54, fields should be back to non-multiline by default

<img width="430" alt="Screenshot 2022-04-26 at 7 59 03 PM" src="https://user-images.githubusercontent.com/41856541/165295131-8a74b12b-799d-4c3a-806e-bf8f43f990da.png">
 