### PR TITLE
Update QR code link and modal

### DIFF
--- a/src/components/GeneralRoomModal/GeneralRoomModal.jsx
+++ b/src/components/GeneralRoomModal/GeneralRoomModal.jsx
@@ -39,6 +39,7 @@ import { GeneralButton } from '../GeneralButton/GeneralButton';
 import { GeneralTextField } from '../GeneralTextField/GeneralTextField';
 import { CHARACTER_MAP } from '../../models/storyMap';
 import { CharacterAvatar } from '../CharacterAvatar/CharacterAvatar';
+import { getGameUrl } from '../../utils';
 
 function ModalStepIcon(props) {
   const { active, completed, className } = props;
@@ -61,11 +62,6 @@ function ModalStepIcon(props) {
 }
 
 const SuccessPanel = ({ createdOrEditedRoom, handleCloseModal }) => {
-  // TODO: refactor?
-  const getGameUrl = (code) => {
-    return `game.tobeyou.sg/room/${code}`;
-  };
-
   const gameUrl = getGameUrl(createdOrEditedRoom.code);
 
   return (
@@ -97,7 +93,7 @@ const SuccessPanel = ({ createdOrEditedRoom, handleCloseModal }) => {
         </Typography>
         <QRCode size={128} value={gameUrl} />
         <Typography m='12px 0 18px 0' variant={'h6'}>
-          <Link target='_blank' color='inherit' href={'https://' + gameUrl}>
+          <Link target='_blank' color='inherit' href={gameUrl}>
             {gameUrl}
           </Link>
         </Typography>

--- a/src/components/GeneralRoomModal/QrModal.jsx
+++ b/src/components/GeneralRoomModal/QrModal.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import QRCode from 'react-qr-code';
-import { Box, Modal } from '@mui/material';
+import { Link, Modal, Typography } from '@mui/material';
 import { getGameUrl } from '../../utils';
+import { ModalBox } from '../GeneralRoomModal/StyledRoomModalComponents';
 
 const QrModal = (props) => {
   const { isModalOpen, setIsModalOpen, room } = props;
@@ -16,9 +17,17 @@ const QrModal = (props) => {
       onClose={handleCloseModal}
       aria-labelledby='qr-modal'
     >
-      <Box>
-        <QRCode value={gameUrl} />
-      </Box>
+      <ModalBox>
+        <Typography variant='h4' sx={{ mb: 2, fontWeight: 800 }}>
+          Share with your class
+        </Typography>
+        <QRCode size={256} value={gameUrl} />
+        <Typography m='12px 0 18px 0' variant={'h6'}>
+          <Link target='_blank' color='inherit' href={gameUrl}>
+            {gameUrl}
+          </Link>
+        </Typography>
+      </ModalBox>
     </Modal>
   );
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 export const getGameUrl = (code) => {
-  return `game.tobeyou.sg/room/${code}`;
+  return `https://game.tobeyou.sg/room/${code}`;
 };
 
 // Hook. Source: https://usehooks.com/useEventListener/


### PR DESCRIPTION
This PR adds a basic QR modal, and adds a `https://` to the front of the game URL in links and QR codes (from `game.tobeyou.sg/room/ABCDEF` to `https://game.tobeyou.sg/room/ABCDEF`)

<img width="425" alt="Screenshot 2022-04-28 at 12 09 31 AM" src="https://user-images.githubusercontent.com/41856541/165563279-6a0fce6e-a17c-46db-aadc-458cba39b464.png">

<img width="1004" alt="Screenshot 2022-04-28 at 12 09 07 AM" src="https://user-images.githubusercontent.com/41856541/165563206-6a073f10-f204-42bb-b6ab-f482c1cb6eec.png">

