### PR TITLE
Add co-facilitator modal

### DIFF
--- a/src/components/GeneralRoomModal/CoFacilitatorModal.jsx
+++ b/src/components/GeneralRoomModal/CoFacilitatorModal.jsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Typography } from '@mui/material';
+import { ModalBox } from '../GeneralRoomModal/StyledRoomModalComponents';
+import { GeneralButton } from '../../components/GeneralButton/GeneralButton';
+import { GeneralTextField } from '../../components/GeneralTextField/GeneralTextField';
+import { getDbUser, getDbUserFromEmail } from '../../models/userModel';
+import { updateDbRoom } from '../../models/roomModel';
+import { useSnackbar } from '../../contexts/SnackbarContext';
+
+const CoFacilitatorModal = (props) => {
+  const { isModalOpen, setIsModalOpen, room, loadRooms } = props;
+  const { setSnackbar } = useSnackbar();
+
+  const [formData, setFormData] = useState({ email: '' });
+  const [facilitatorEmails, setFacilitatorEmails] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setFacilitatorEmails(null);
+  };
+
+  const handleChange = (event) => {
+    setFormData({
+      ...formData,
+      [event.target.name]: event.target.value.trim(),
+    });
+  };
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true);
+    const email = formData.email;
+    try {
+      const coFacilitator = await getDbUserFromEmail(email);
+      console.log(coFacilitator);
+      if (coFacilitator === null) {
+        // TODO: send email instead of throwing an error
+        throw new Error(`No facilitator with the email '${email}' exists.`);
+      } else if (!room.facilitatorIds.includes(coFacilitator.id)) {
+        // TODO: send success email
+        const newFacilitatorIds = [...room.facilitatorIds, coFacilitator.id];
+        const newRoom = { ...room, facilitatorIds: newFacilitatorIds };
+        await updateDbRoom(newRoom);
+        await loadRooms();
+        handleCloseModal();
+        setSnackbar({
+          message: `The facilitator with email ${email} has been added to the room.`,
+          open: true,
+          type: 'success',
+        });
+      } else {
+        throw new Error(
+          `The facilitator with email '${email}' is already in the room.`
+        );
+      }
+    } catch (error) {
+      setSnackbar({
+        message: error.message,
+        open: true,
+        type: 'error',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const getData = async () => {
+    if (!isModalOpen) return;
+    const facilitators = await Promise.all(
+      room.facilitatorIds.map((facilId) => getDbUser(facilId))
+    );
+    setFacilitatorEmails(facilitators.map((facil) => facil.email));
+  };
+
+  useEffect(() => getData(), [isModalOpen]);
+
+  return (
+    <Modal
+      open={isModalOpen}
+      onClose={handleCloseModal}
+      aria-labelledby='qr-modal'
+    >
+      <ModalBox>
+        <Typography variant='h4' sx={{ mb: 2, fontWeight: 800 }}>
+          Facilitators
+        </Typography>
+        {facilitatorEmails?.map((facilEmail) => {
+          return <Typography key={facilEmail}>{facilEmail}</Typography>;
+        })}
+        <Typography variant='h4' sx={{ m: 2 }}>
+          Add a Co-Facilitator
+        </Typography>
+        <GeneralTextField
+          name='email'
+          type='email'
+          placeholder='email@email.com'
+          label='Email:'
+          onChange={handleChange}
+          disabled={isSubmitting}
+        />
+        <GeneralButton
+          sx={{ width: 250 }}
+          onClick={handleSubmit}
+          disabled={isSubmitting}
+        >
+          Add
+        </GeneralButton>
+      </ModalBox>
+    </Modal>
+  );
+};
+export default CoFacilitatorModal;

--- a/src/components/RoomCard/RoomCard.jsx
+++ b/src/components/RoomCard/RoomCard.jsx
@@ -6,6 +6,7 @@ import {
   QrCode,
   ArchiveOutlined,
   DeleteOutlineOutlined,
+  PeopleOutlined,
 } from '@mui/icons-material';
 import { Card, Grid, Typography } from '@mui/material';
 import { FlexBoxSpaceBetween, FlexBoxCenter } from '../styled/general';
@@ -16,6 +17,7 @@ const RoomCard = (props) => {
   const {
     room,
     handleSoftDelete,
+    handleAddCoFacilitator,
     handleQrModal,
     toggleIsActive,
     handleEdit,
@@ -55,6 +57,16 @@ const RoomCard = (props) => {
               onClick={(e) => {
                 e.stopPropagation();
                 handleSoftDelete();
+              }}
+            />
+            <PeopleOutlined
+              sx={{
+                color: (theme) => theme.palette.lapis[100],
+                marginLeft: '4px',
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleAddCoFacilitator();
               }}
             />
             <EditOutlined

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -48,7 +48,7 @@ export const getDbUserFromEmail = async (email) => {
     .where('email', '==', email)
     .get();
   if (snapshot.docs.length === 0) {
-    throw new Error(`No user exists for the email '${email}'`);
+    return null;
   }
   const userDoc = snapshot.docs[0];
   const userData = { id: userDoc.id, ...userDoc.data() };

--- a/src/page/Home.jsx
+++ b/src/page/Home.jsx
@@ -12,6 +12,7 @@ import RoomCard from '../components/RoomCard/RoomCard';
 import NewRoomModal from '../components/GeneralRoomModal/NewRoomModal';
 import EditRoomModal from '../components/GeneralRoomModal/EditRoomModal';
 import QrModal from '../components/GeneralRoomModal/QrModal';
+import CoFacilitatorModal from '../components/GeneralRoomModal/CoFacilitatorModal';
 import {
   FlexBoxSpaceBetween,
   FlexBoxCenter,
@@ -44,11 +45,9 @@ const Home = () => {
   const [isQrModalOpen, setIsQrModalOpen] = useState(false);
   const [qrModalRoom, setQrModalRoom] = useState(null);
 
-  // const [roomFilter, setRoomFilter] = useState({none: "Filter"})
-
-  // const handleChange = (event) => {
-  //   setRoomFilter({ [event.target.value]: filterOptions[event.target.value] });
-  // };
+  const [isCoFacilitatorModalOpen, setIsCoFacilitatorModalOpen] =
+    useState(false);
+  const [coFacilitatorModalRoom, setCoFacilitatorModalRoom] = useState(false);
 
   async function handleSoftDeleteRoom(id) {
     const isConfirm = confirm('Are you sure you want to delete this room?');
@@ -80,6 +79,12 @@ const Home = () => {
     const room = rooms.find((room) => room.id === id);
     setQrModalRoom(room);
     setIsQrModalOpen(true);
+  }
+
+  async function handleAddCoFacilitator(id) {
+    const room = rooms.find((room) => room.id === id);
+    setCoFacilitatorModalRoom(room);
+    setIsCoFacilitatorModalOpen(true);
   }
 
   async function toggleIsActiveRoom(id) {
@@ -172,6 +177,7 @@ const Home = () => {
                 room={room}
                 toggleIsActive={() => toggleIsActiveRoom(room.id)}
                 handleSoftDelete={() => handleSoftDeleteRoom(room.id)}
+                handleAddCoFacilitator={() => handleAddCoFacilitator(room.id)}
                 handleQrModal={() => handleQrModal(room.id)}
                 roomStatus={room.isActive}
                 handleEdit={() => handleEditRoom(room.id)}
@@ -250,6 +256,12 @@ const Home = () => {
           isModalOpen={isQrModalOpen}
           setIsModalOpen={setIsQrModalOpen}
           room={qrModalRoom}
+        />
+        <CoFacilitatorModal
+          isModalOpen={isCoFacilitatorModalOpen}
+          setIsModalOpen={setIsCoFacilitatorModalOpen}
+          room={coFacilitatorModalRoom}
+          loadRooms={loadRooms}
         />
       </Box>
     </Box>


### PR DESCRIPTION
Resolves #82 

This PR adds a co-facilitator modal to the main dashboard. The modal is brought up by clicking on the 2nd icon (people icon) on the room card.

<img width="380" alt="Screenshot 2022-05-16 at 11 01 52 PM" src="https://user-images.githubusercontent.com/41856541/168623433-3431db9b-5cd0-412a-9a3d-b7ab6d020eee.png">

<img width="420" alt="Screenshot 2022-05-16 at 10 59 06 PM" src="https://user-images.githubusercontent.com/41856541/168623280-89de4ba1-ecd5-4d4a-88d9-39b8530a9e60.png">

Is the design generally OK?

Currently the email sending has not been set up. Also, a success happens only if the co-facilitator with the email exists; otherwise if no co-facilitator with the email exists, it fails with an error. (To be modified in the future)