### PR TITLE
Add sending emails to co-facilitators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tobeyou_facilitator",
       "version": "0.1.0",
       "dependencies": {
+        "@emailjs/browser": "^3.6.2",
         "@emotion/core": "^10.1.1",
         "@emotion/react": "^11.7.0",
         "@emotion/styled": "^11.6.0",
@@ -3377,6 +3378,14 @@
         "moment": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@emailjs/browser": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-3.6.2.tgz",
+      "integrity": "sha512-Swc8w+vwDX4XPy6tPegOFGSwHqNiEmEsIKbtAkqHo2WqnS0ORZUnnuZats2R3XqwfxNQD0F6RwnlVWHIMf6sCQ==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -45639,6 +45648,11 @@
       "requires": {
         "@date-io/core": "^2.11.0"
       }
+    },
+    "@emailjs/browser": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-3.6.2.tgz",
+      "integrity": "sha512-Swc8w+vwDX4XPy6tPegOFGSwHqNiEmEsIKbtAkqHo2WqnS0ORZUnnuZats2R3XqwfxNQD0F6RwnlVWHIMf6sCQ=="
     },
     "@emotion/babel-plugin": {
       "version": "11.3.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@emailjs/browser": "^3.6.2",
     "@emotion/core": "^10.1.1",
     "@emotion/react": "^11.7.0",
     "@emotion/styled": "^11.6.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { send } from '@emailjs/browser';
 
 export const getGameUrl = (code) => {
   return `https://game.tobeyou.sg/room/${code}`;
@@ -64,4 +65,19 @@ export function breakIntoLines(labels) {
   });
 
   return result;
+}
+
+export function sendFacilitatorEmail(roomCode, toEmail, message) {
+  const templateParams = {
+    room_code: roomCode,
+    to_email: toEmail,
+    message: message,
+  };
+
+  send(
+    'service_q3gnqrp',
+    'template_6oavgta',
+    templateParams,
+    'user_kmfKhjRSSwoovXNarQivp'
+  );
 }


### PR DESCRIPTION
Resolves #96

Emails sent will be formatted like the one below (except with the message italics removed!):

<img width="623" alt="Screenshot 2022-05-23 at 6 10 51 PM" src="https://user-images.githubusercontent.com/41856541/169859248-eba08014-31e1-4f94-aa8b-5f5e296062e2.png">

- Are the email messages OK?
- Are the snackbar messages OK?
- Is it OK to display the room code like abcdef, rather than the room title (e.g. Class 4F)?
- The service/template IDs and the public key are exposed here, is that OK? Since it's a public rather than a private key? Otherwise we could try setting them as env vars instead


