### PR TITLE
Fix game choices with undefined global variables

### DIFF
--- a/src/page/GameChoices.jsx
+++ b/src/page/GameChoices.jsx
@@ -74,9 +74,9 @@ const GameChoices = () => {
     );
     // Have to perform N+1 query unfortunately, can potentially be a performance issue
     const dbSavedStates = await Promise.all(savedStateIds.map(getDbSavedState));
-    const dbAllGlobalVariables = dbSavedStates.map(
-      (dbSavedState) => dbSavedState.globalVariables
-    );
+    const dbAllGlobalVariables = dbSavedStates
+      .map((dbSavedState) => dbSavedState.globalVariables)
+      .filter((globalVariables) => globalVariables !== undefined); // some saved states may not have globalVariables defined
     const parsedChartDatas = parseChartDatas(dbAllGlobalVariables);
     setChartDatas(parsedChartDatas);
   }


### PR DESCRIPTION
Fixes #118

The previous code assumes that each saved state has a `globalVariables` field, but some saved states may not have their global variables saved yet, and so these undefined fields cause an error.

This fixes the issue by filtering out the undefined global variables.