### PR TITLE
Set node version to 14 for firebase deployment

### DIFF
--- a/.github/workflows/firebase-hosting-merge-release.yml
+++ b/.github/workflows/firebase-hosting-merge-release.yml
@@ -25,6 +25,9 @@ jobs:
       REACT_APP_FIREBASE_MEASUREMENT_ID: G-GZRNC2KL45
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - run: npm install && CI=false npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
The GitHub action for deployment is failing during `npm install`, likely because it's using an updated node version that's incompatible with our dependencies. This PR sets the node version to 14 (similar to the other GitHub action), which should resolve the issue