### PR TITLE
Fixed font-size and margin misalignment on the chart screens

### DIFF
--- a/src/components/ChartScreen/ChartScreen.jsx
+++ b/src/components/ChartScreen/ChartScreen.jsx
@@ -225,12 +225,12 @@ const ChartScreen = ({
       <Typography
         variant='h3'
         sx={{
-          fontSize: '52px',
+          fontSize: '36px',
           color: 'white',
           mb: 5,
           maxWidth: '80%',
           textAlign: 'center',
-          mt: '-100px',
+          mt: '-50px',
         }}
       >
         {chartData?.title}


### PR DESCRIPTION
The question text was clipped by the topbar when viewed on tablet screens. This fix reduces the font size and adds a larger margin-top.
Old layout:
![image](https://user-images.githubusercontent.com/6855844/177920462-6a504ddb-a09f-451c-99df-a8563ab22809.png)


New layout:
![image](https://user-images.githubusercontent.com/6855844/177920410-bcd7f85e-32cd-4772-a2c3-3b653445db4d.png)
