### PR TITLE
Completion $ appears in the center of the blue progress bar

### DIFF
--- a/src/components/GeneralProgressBar/GeneralProgressBar.jsx
+++ b/src/components/GeneralProgressBar/GeneralProgressBar.jsx
@@ -22,16 +22,19 @@ export const GeneralProgressBar = ({ completedStudents, totalStudents }) => {
           height: '40px',
           margin: '16px 0',
         }}
-      />
-      <Typography
-        sx={{
-          fontWeight: 700,
-          fontSize: '24px',
-          color: (theme) => theme.palette.midnight.dark1,
-        }}
       >
-        {isNaN(percentage) ? null : `${percentage}%`}
-      </Typography>
+        <Typography
+          sx={{
+            fontWeight: 700,
+            fontSize: '24px',
+            position: 'relative',
+            textAlign: 'center',
+            color: (theme) => theme.palette.midnight.dark1,
+          }}
+        >
+          {isNaN(percentage) ? null : `${percentage}%`}
+        </Typography>
+      </Box>
     </FlexBoxAlign>
   );
 };


### PR DESCRIPTION
This is more logical than the proposed UI, because if the % appears on the white portion, the user may get confused as to what the number refers to (% done or incomplete). The text is now centered in the blue portion. Also, fixed a small bug where 100% completion does not fill up the blue progress bar. Minor fix to round the bar still pending

![Screenshot 2022-07-09 at 2 56 29 PM](https://user-images.githubusercontent.com/6855844/178095349-e61e18c4-39b9-4d0d-9d15-98fa74c97247.jpg)
![image](https://user-images.githubusercontent.com/6855844/178095363-61a1416d-ac24-4d20-bfb3-912ad8f884d3.png)

