### PR TITLE
Use cloud functions to fetch emails involving other users

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,6 +1,7 @@
 import firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/firestore';
+import 'firebase/functions';
 
 const config = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
@@ -22,3 +23,4 @@ export const googleAuthProviderId =
 export const facebookAuthProviderId =
   firebase.auth.FacebookAuthProvider.PROVIDER_ID;
 export const firestore = firebase.firestore();
+export const functions = firebase.functions();

--- a/src/models/functions.js
+++ b/src/models/functions.js
@@ -1,0 +1,11 @@
+import { functions } from '../firebase';
+
+export const getCoFacilitatorEmailsForRoom = functions.httpsCallable(
+  'getCoFacilitatorEmailsForRoom'
+);
+export const getParticipantIdsToEmailsForRoom = functions.httpsCallable(
+  'getParticipantIdsToEmailsForRoom'
+);
+export const inviteUserToBeCofacilitatorForRoom = functions.httpsCallable(
+  'inviteUserToBeCofacilitatorForRoom'
+);

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -4,20 +4,21 @@ import { firestore } from '../firebase';
  * Creates a user and sets it to be a facilitator, if the user does not exist.
  */
 export const createDbUserIfNotExists = async (id, email) => {
-  const obj = {
-    id,
-    email,
-  };
+  const userObj = { id };
+  const emailObj = { email };
 
   try {
-    const userRef = firestore.collection('users').doc(obj.id);
+    const userRef = firestore.collection('users').doc(userObj.id);
+    const emailRef = firestore.collection('emails').doc(userObj.id);
     const user = await userRef.get();
     if (user.exists) {
       // Give the existing user new facilitator fields
-      await userRef.update(obj, { merge: true });
+      await userRef.update(userObj, { merge: true });
+      await emailRef.update(emailObj, { merge: true });
     } else {
       // Create the new facilitator
-      await userRef.set(obj);
+      await userRef.set(userObj);
+      await emailRef.set(emailObj);
     }
   } catch (err) {
     throw new Error(`Error at createDbUserIfNotExists: ${err}`);
@@ -40,17 +41,4 @@ export const getDbUser = async (id) => {
   } catch (err) {
     throw new Error(`Error at getDbUser: ${err}`);
   }
-};
-
-export const getDbUserFromEmail = async (email) => {
-  const snapshot = await firestore
-    .collection('users')
-    .where('email', '==', email)
-    .get();
-  if (snapshot.docs.length === 0) {
-    return null;
-  }
-  const userDoc = snapshot.docs[0];
-  const userData = { id: userDoc.id, ...userDoc.data() };
-  return userData;
 };

--- a/src/page/Room.jsx
+++ b/src/page/Room.jsx
@@ -4,10 +4,10 @@ import { useNavigate, useParams } from 'react-router';
 import * as XLSX from 'xlsx';
 import { useAuth } from '../contexts/AuthContext';
 import { getDbReflectionResponses } from '../models/reflectionResponseModel';
+import { getParticipantIdsToEmailsForRoom } from '../models/functions';
 import { getDbRoomByCode } from '../models/roomModel';
 import { getDbQuizAnswersChartDatas } from '../models/quizAnswerModel';
 import { getDbGameChoicesChartDatas } from '../models/savedStateModel';
-import { getDbUser } from '../models/userModel';
 import { REFLECTION_ID_MAP } from '../models/storyMap';
 import GLOBAL_VAR_MAP from '../models/globalVarMap';
 import { GeneralBreadcrumbs } from '../components/GeneralBreadcrumbs/GeneralBreadcrumbs';
@@ -391,14 +391,10 @@ const Room = () => {
     setCompletionRateNumeratorIds(numeratorIds);
     setCompletionRateDenominatorIds(dbRoom.participantIds);
 
-    // Get participant emails for completion rate - have to perform N+1 query unfortunately
-    const participants = await Promise.all(
-      dbRoom.participantIds.map((participantId) => getDbUser(participantId))
-    );
-    const participantsIdToEmailMap = {};
-    for (let participant of participants) {
-      participantsIdToEmailMap[participant.id] = participant.email;
-    }
+    // Get participant emails for completion rate
+    const participantsIdToEmailMap = (
+      await getParticipantIdsToEmailsForRoom({ roomId: dbRoom.id })
+    ).data;
     setParticipantsIdToEmailMap(participantsIdToEmailMap);
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from 'react';
-import { send } from '@emailjs/browser';
 
 export const getGameUrl = (code) => {
   return `https://game.tobeyou.sg/room/${code}`;
@@ -62,19 +61,4 @@ export function breakIntoLines(labels) {
   });
 
   return result;
-}
-
-export function sendFacilitatorEmail(roomCode, toEmail, message) {
-  const templateParams = {
-    room_code: roomCode,
-    to_email: toEmail,
-    message: message,
-  };
-
-  send(
-    'service_q3gnqrp',
-    'template_6oavgta',
-    templateParams,
-    'user_kmfKhjRSSwoovXNarQivp'
-  );
 }


### PR DESCRIPTION
With the migration to separate out emails into a separate collection, we'll need to retrieve the emails of other users (i.e. participants, co-facilitators) from cloud functions instead.

Features:
- When creating a new db user: do not save email field, create a new email doc instead
- Use cloud functions to retrieve participants' emails
- Use cloud functions to retrieve co-facilitators' emails
- Use cloud functions to send email invites to co-facilitators and add them to the room (pending https://github.com/bettersg/besomebody_v3/pull/345)